### PR TITLE
Add the unstable feature to the Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ description = "Infrastructure for measuring the total runtime size of an object 
 license = "MPL-2.0"
 repository = "https://github.com/servo/heapsize"
 
+[features]
+unstable = []
+
 [dependencies]
 libc = "0.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 
 //! Data structure measurement.
 
+#![cfg_attr(feature = "unstable", feature(hashmap_hasher))]
+
 extern crate libc;
 
 use libc::{c_void, size_t};


### PR DESCRIPTION
Needed for `rust-selectors`, which needs to be able to use the hasher feature.