### PR TITLE
Increment the version, to update on Crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heapsize"
-version = "0.1.0"
+version = "0.1.1"
 authors = [ "The Servo Project Developers" ]
 description = "Infrastructure for measuring the total runtime size of an object on the heap"
 license = "MPL-2.0"


### PR DESCRIPTION
We should probably upload the plugin there, too. [That is blocking implementations.](https://github.com/servo/string-cache/pull/105)