### PR TITLE
Bump crates, again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heapsize"
-version = "0.1.2"
+version = "0.1.3"
 authors = [ "The Servo Project Developers" ]
 description = "Infrastructure for measuring the total runtime size of an object on the heap"
 license = "MPL-2.0"


### PR DESCRIPTION
Somehow crates.io already has a 0.1.2, probably was published without a merge

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/heapsize/17)
<!-- Reviewable:end -->
