### PR TITLE
Fix the implementation of HeapSizeOf for LinkedList

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ impl<T: HeapSizeOf> HeapSizeOf for LinkedList<T> {
     fn heap_size_of_children(&self) -> usize {
         let mut size = 0;
         for item in self {
-            size += 2 * size_of::<usize>() + item.heap_size_of_children();
+            size += 2 * size_of::<usize>() + size_of::<T>() + item.heap_size_of_children();
         }
         size
     }


### PR DESCRIPTION
Forgot the size of the T field itself in the list nodes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/heapsize/25)
<!-- Reviewable:end -->
