### PR TITLE
Remove now default 'sudo: false'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: rust
 rust: nightly
 notifications:


### PR DESCRIPTION
'sudo: false' is now default on Travis CI

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/heapsize/38)
<!-- Reviewable:end -->
