### PR TITLE
Make it compile with the current beta release branch

### DIFF
--- a/derive/lib.rs
+++ b/derive/lib.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![cfg_attr(not(test), feature(proc_macro, proc_macro_lib))]
-
 #[cfg(not(test))] extern crate proc_macro;
 #[macro_use] extern crate quote;
 extern crate syn;

--- a/derive/test.rs
+++ b/derive/test.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro)]
 #[macro_use] extern crate heapsize_derive;
 
 mod heapsize {


### PR DESCRIPTION
Removes the now unneccessary feature attributes to be able to compile the crate with the current beta release.