### PR TITLE
Make heap_size_of_impl consistently private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ unsafe fn heap_size_of_impl(ptr: *const c_void) -> usize {
 }
 
 #[cfg(target_os = "windows")]
-pub unsafe fn heap_size_of_impl(mut ptr: *const c_void) -> usize {
+unsafe fn heap_size_of_impl(mut ptr: *const c_void) -> usize {
     let heap = GetProcessHeap();
 
     if HeapValidate(heap, 0, ptr) == 0 {


### PR DESCRIPTION
I'm assuming this was accidentally public on Windows?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/heapsize/76)
<!-- Reviewable:end -->
