### PR TITLE
Implement HeapSizeOf for raw pointers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,25 @@ impl<'a, T: ?Sized> HeapSizeOf for &'a T {
     }
 }
 
+// The implementations for *mut T and *const T are designed for use cases like LinkedHashMap where
+// you have a data structure which internally maintains an e.g. HashMap parameterized with raw
+// pointers. We want to be able to rely on the standard HeapSizeOf implementation for `HashMap`,
+// and can handle the contribution of the raw pointers manually.
+//
+// These have to return 0 since we don't know if the pointer is pointing to a heap allocation or
+// even valid memory.
+impl<T: ?Sized> HeapSizeOf for *mut T {
+    fn heap_size_of_children(&self) -> usize {
+        0
+    }
+}
+
+impl<T: ?Sized> HeapSizeOf for *const T {
+    fn heap_size_of_children(&self) -> usize {
+        0
+    }
+}
+
 impl<T: HeapSizeOf> HeapSizeOf for Option<T> {
     fn heap_size_of_children(&self) -> usize {
         match *self {


### PR DESCRIPTION
These return 0 since we don't know if the pointer is valid or not. This
is a bit dubious, but is designed to support cases like LinkedHashMap
where you have some data structure like a HashMap used with raw pointers
in its type parameters. We want to be able to rely on the standard
HeapSizeOf implementation for HashMap, and then do the extra bookkeeping
of managing the space consumed by the raw pointers ourselves.

I'm not sure if this is the "right" approach or not, but it seems slightly preferable to the alternative of manually copying the HashMap size estimate into LinkedHashMap and trying to keep it in sync with this crate's.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/heapsize/77)
<!-- Reviewable:end -->
