### PR TITLE
Add opt in for weaker tests, for non-jemalloc allocators.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ kernel32-sys = "0.2.1"
 
 [features]
 unstable = []
+
+# https://github.com/servo/heapsize/issues/74
+flexible-tests = []

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,7 +15,7 @@ pub const EMPTY: *mut () = 0x1 as *mut ();
 mod unstable {
     extern crate alloc;
 
-    use heapsize::{HeapSizeOf, heap_size_of};
+    use heapsize::heap_size_of;
     use std::os::raw::c_void;
 
     #[repr(C, simd)]
@@ -91,12 +91,12 @@ mod unstable {
         let x = Box::new(OverAligned(0, 0, 0, 0));
         assert_eq!(unsafe { heap_size_of(&*x as *const _ as *const c_void) }, 32 + 32);
     }
+}
 
-    #[test]
-    fn test_boxed_str() {
-        let x = "raclette".to_owned().into_boxed_str();
-        assert_eq!(x.heap_size_of_children(), 8);
-    }
+#[test]
+fn test_boxed_str() {
+    let x = "raclette".to_owned().into_boxed_str();
+    assert_eq!(x.heap_size_of_children(), 8);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,7 +9,26 @@ extern crate heapsize;
 use heapsize::{HeapSizeOf, heap_size_of};
 use std::os::raw::c_void;
 
-pub const EMPTY: *mut () = 0x1 as *mut ();
+const EMPTY: *mut () = 0x1 as *mut ();
+
+/// https://github.com/servo/heapsize/issues/74
+#[cfg(feature = "flexible-tests")]
+macro_rules! assert_size {
+    ($actual: expr, $expected: expr) => {
+        {
+            let actual = $actual;
+            let expected = $expected;
+            assert!(actual >= expected, "expected {:?} >= {:?}", actual, expected)
+        }
+    }
+}
+
+#[cfg(not(feature = "flexible-tests"))]
+macro_rules! assert_size {
+    ($actual: expr, $expected: expr) => {
+        assert_eq!($actual, $expected)
+    }
+}
 
 #[cfg(feature = "unstable")]
 mod unstable {
@@ -32,22 +51,22 @@ mod unstable {
         unsafe {
             // A 64 byte request is allocated exactly.
             let x = alloc::heap::allocate(64, 0);
-            assert_eq!(heap_size_of(x as *const c_void), 64);
+            assert_size!(heap_size_of(x as *const c_void), 64);
             alloc::heap::deallocate(x, 64, 0);
 
             // A 255 byte request is rounded up to 256 bytes.
             let x = alloc::heap::allocate(255, 0);
-            assert_eq!(heap_size_of(x as *const c_void), 256);
+            assert_size!(heap_size_of(x as *const c_void), 256);
             alloc::heap::deallocate(x, 255, 0);
 
             // A 1MiB request is allocated exactly.
             let x = alloc::heap::allocate(1024 * 1024, 0);
-            assert_eq!(heap_size_of(x as *const c_void), 1024 * 1024);
+            assert_size!(heap_size_of(x as *const c_void), 1024 * 1024);
             alloc::heap::deallocate(x, 1024 * 1024, 0);
 
             // An overaligned 1MiB request is allocated exactly.
             let x = alloc::heap::allocate(1024 * 1024, 32);
-            assert_eq!(heap_size_of(x as *const c_void), 1024 * 1024);
+            assert_size!(heap_size_of(x as *const c_void), 1024 * 1024);
             alloc::heap::deallocate(x, 1024 * 1024, 32);
         }
     }
@@ -58,22 +77,22 @@ mod unstable {
         unsafe {
             // A 64 byte request is allocated exactly.
             let x = alloc::heap::allocate(64, 0);
-            assert_eq!(heap_size_of(x as *const c_void), 64);
+            assert_size!(heap_size_of(x as *const c_void), 64);
             alloc::heap::deallocate(x, 64, 0);
 
             // A 255 byte request is allocated exactly.
             let x = alloc::heap::allocate(255, 0);
-            assert_eq!(heap_size_of(x as *const c_void), 255);
+            assert_size!(heap_size_of(x as *const c_void), 255);
             alloc::heap::deallocate(x, 255, 0);
 
             // A 1MiB request is allocated exactly.
             let x = alloc::heap::allocate(1024 * 1024, 0);
-            assert_eq!(heap_size_of(x as *const c_void), 1024 * 1024);
+            assert_size!(heap_size_of(x as *const c_void), 1024 * 1024);
             alloc::heap::deallocate(x, 1024 * 1024, 0);
 
             // An overaligned 1MiB request is over-allocated.
             let x = alloc::heap::allocate(1024 * 1024, 32);
-            assert_eq!(heap_size_of(x as *const c_void), 1024 * 1024 + 32);
+            assert_size!(heap_size_of(x as *const c_void), 1024 * 1024 + 32);
             alloc::heap::deallocate(x, 1024 * 1024, 32);
         }
     }
@@ -82,21 +101,21 @@ mod unstable {
     #[test]
     fn test_simd() {
         let x = Box::new(OverAligned(0, 0, 0, 0));
-        assert_eq!(unsafe { heap_size_of(&*x as *const _ as *const c_void) }, 32);
+        assert_size!(unsafe { heap_size_of(&*x as *const _ as *const c_void) }, 32);
     }
 
     #[cfg(target_os = "windows")]
     #[test]
     fn test_simd() {
         let x = Box::new(OverAligned(0, 0, 0, 0));
-        assert_eq!(unsafe { heap_size_of(&*x as *const _ as *const c_void) }, 32 + 32);
+        assert_size!(unsafe { heap_size_of(&*x as *const _ as *const c_void) }, 32 + 32);
     }
 }
 
 #[test]
 fn test_boxed_str() {
     let x = "raclette".to_owned().into_boxed_str();
-    assert_eq!(x.heap_size_of_children(), 8);
+    assert_size!(x.heap_size_of_children(), 8);
 }
 
 #[test]
@@ -111,7 +130,7 @@ fn test_heap_size() {
 
     unsafe {
         // EMPTY is the special non-null address used to represent zero-size allocations.
-        assert_eq!(heap_size_of(EMPTY as *const c_void), 0);
+        assert_size!(heap_size_of(EMPTY as *const c_void), 0);
     }
 
     //-----------------------------------------------------------------------
@@ -119,53 +138,53 @@ fn test_heap_size() {
 
     // Not on the heap; 0 bytes.
     let x = 0i64;
-    assert_eq!(x.heap_size_of_children(), 0);
+    assert_size!(x.heap_size_of_children(), 0);
 
     // An i64 is 8 bytes.
     let x = Box::new(0i64);
-    assert_eq!(x.heap_size_of_children(), 8);
+    assert_size!(x.heap_size_of_children(), 8);
 
     // An ascii string with 16 chars is 16 bytes in UTF-8.
     let string = String::from("0123456789abcdef");
-    assert_eq!(string.heap_size_of_children(), 16);
+    assert_size!(string.heap_size_of_children(), 16);
 
     let string_ref: (&String, ()) = (&string, ());
-    assert_eq!(string_ref.heap_size_of_children(), 0);
+    assert_size!(string_ref.heap_size_of_children(), 0);
 
     let slice: &str = &*string;
-    assert_eq!(slice.heap_size_of_children(), 0);
+    assert_size!(slice.heap_size_of_children(), 0);
 
     // Not on the heap.
     let x: Option<i32> = None;
-    assert_eq!(x.heap_size_of_children(), 0);
+    assert_size!(x.heap_size_of_children(), 0);
 
     // Not on the heap.
     let x = Some(0i64);
-    assert_eq!(x.heap_size_of_children(), 0);
+    assert_size!(x.heap_size_of_children(), 0);
 
     // The `Some` is not on the heap, but the Box is.
     let x = Some(Box::new(0i64));
-    assert_eq!(x.heap_size_of_children(), 8);
+    assert_size!(x.heap_size_of_children(), 8);
 
     // Not on the heap.
     let x = ::std::sync::Arc::new(0i64);
-    assert_eq!(x.heap_size_of_children(), 0);
+    assert_size!(x.heap_size_of_children(), 0);
 
     // The `Arc` is not on the heap, but the Box is.
     let x = ::std::sync::Arc::new(Box::new(0i64));
-    assert_eq!(x.heap_size_of_children(), 8);
+    assert_size!(x.heap_size_of_children(), 8);
 
     // Zero elements, no heap storage.
     let x: Vec<i64> = vec![];
-    assert_eq!(x.heap_size_of_children(), 0);
+    assert_size!(x.heap_size_of_children(), 0);
 
     // Four elements, 8 bytes per element.
     let x = vec![0i64, 1i64, 2i64, 3i64];
-    assert_eq!(x.heap_size_of_children(), 32);
+    assert_size!(x.heap_size_of_children(), 32);
 }
 
 #[test]
 fn test_boxed_slice() {
     let x = vec![1i64, 2i64].into_boxed_slice();
-    assert_eq!(x.heap_size_of_children(), 16)
+    assert_size!(x.heap_size_of_children(), 16)
 }


### PR DESCRIPTION
Fix #74

Distributions packages can use `cargo test --features flexible-tests`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/heapsize/79)
<!-- Reviewable:end -->
