### PR TITLE
Bump version to 0.4.1 to reflect re-licensing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heapsize"
-version = "0.4.0"
+version = "0.4.1"
 authors = [ "The Servo Project Developers" ]
 description = "Infrastructure for measuring the total runtime size of an object on the heap"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
rust-url would like to depend on a relicensed version of heapsize. (https://github.com/servo/rust-url/issues/317).

The re-licensing has already happened, but a version bump (at least minor version) and re-publishing on crates.io is required for that.

This PR simply bumps the version to `0.4.1`. Once this get's published to crates.io, other crates can depend on heapsize with MIT/apache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/heapsize/85)
<!-- Reviewable:end -->
