### PR TITLE
Add iOS support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ unsafe fn heap_size_of_impl(ptr: *const c_void) -> usize {
     // this function doesn't modify the contents of the block that `ptr` points to, so we use
     // `*const c_void` here.
     extern "C" {
-		#[cfg_attr(any(prefixed_jemalloc, target_os = "macos", target_os = "android"), link_name = "je_malloc_usable_size")]
+		#[cfg_attr(any(prefixed_jemalloc, target_os = "macos", target_os = "ios", target_os = "android"), link_name = "je_malloc_usable_size")]
         fn malloc_usable_size(ptr: *const c_void) -> usize;
     }
     malloc_usable_size(ptr)


### PR DESCRIPTION
Ability to build heapsize for iOS platform have been added in this PR.
For building could be used:
cargo build --target aarch64-apple-ios


r? @larsbergstrom , could you, please, make code review and accept changes?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/heapsize/88)
<!-- Reviewable:end -->
