### PR TITLE
Update winapi to 0.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/servo/heapsize"
 build = "build.rs"
 
 [target.'cfg(windows)'.dependencies]
-kernel32-sys = "0.2.1"
+winapi = { version = "0.3.4", features = ["std", "heapapi"] }
 
 [features]
 unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! Data structure measurement.
 
 #[cfg(target_os = "windows")]
-extern crate kernel32;
+extern crate winapi;
 
 #[cfg(target_os = "windows")]
-use kernel32::{GetProcessHeap, HeapSize, HeapValidate};
+use winapi::um::heapapi::{GetProcessHeap, HeapSize, HeapValidate};
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashSet, HashMap, LinkedList, VecDeque};


### PR DESCRIPTION
`winapi` features enabled

- `std` - to make it `c_void` pointer compatible [link](https://docs.rs/winapi/*/x86_64-pc-windows-msvc/src/winapi/lib.rs.html#31) with the one used by heapsize
- `heapapi` - to enable `heapapi` [link](https://github.com/retep998/winapi-rs#why-am-i-getting-errors-about-unresolved-imports)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/heapsize/91)
<!-- Reviewable:end -->
