### PR TITLE
Bump rust version used by travis to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
- - 1.8.0
+ - 1.11.0
  - nightly
  - beta
  - stable


### PR DESCRIPTION
If there is no reason to keep backwards compatibility with `rust 1.8.0`, let's bump *.travis.yml* to `rust 1.9.0`.

Hopefully it will help with travis build issue described in https://github.com/travis-ci/travis-ci/issues/9128

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/heapsize/95)
<!-- Reviewable:end -->
