### PR TITLE
Update the derive crate

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,6 +15,10 @@ name = "test"
 path = "test.rs"
 
 [dependencies]
-syn = "0.15"
+syn = "0.14"
 quote = "0.6"
 synstructure = "0.9"
+proc-macro2 = "0.4.18"
+
+[dev-dependencies]
+heapsize = { path = ".." }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,6 +15,6 @@ name = "test"
 path = "test.rs"
 
 [dependencies]
-syn = "0.11"
-quote = "0.3"
-synstructure = "0.5"
+syn = "0.15"
+quote = "0.6"
+synstructure = "0.9"

--- a/derive/test.rs
+++ b/derive/test.rs
@@ -1,23 +1,37 @@
-#[macro_use] extern crate heapsize_derive;
+#[macro_use]
+extern crate heapsize_derive;
+extern crate heapsize;
 
-mod heapsize {
-    pub trait HeapSizeOf {
-        fn heap_size_of_children(&self) -> usize;
-    }
-
-    impl<T> HeapSizeOf for Box<T> {
-        fn heap_size_of_children(&self) -> usize {
-            ::std::mem::size_of::<T>()
-        }
-    }
-}
-
+use heapsize::HeapSizeOf;
 
 #[derive(HeapSizeOf)]
-struct Foo([Box<u32>; 2], Box<u8>);
+struct Tuple([Box<u32>; 2], Box<u8>);
 
 #[test]
-fn test() {
-    use heapsize::HeapSizeOf;
-    assert_eq!(Foo([Box::new(1), Box::new(2)], Box::new(3)).heap_size_of_children(), 9);
+fn tuple_struct() {
+    assert_eq!(
+        Tuple([Box::new(1), Box::new(2)], Box::new(3)).heap_size_of_children(),
+        9
+    );
+}
+
+#[derive(HeapSizeOf)]
+struct Normal {
+    first: Tuple,
+    second: Box<(u32, u32)>,
+    #[ignore_heap_size_of = "We don't care about this"]
+    ignored: Vec<Normal>,
+}
+
+#[test]
+fn normal_struct() {
+    let tuple = Tuple([Box::new(1), Box::new(2)], Box::new(3));
+    let normal = Normal {
+        first: tuple,
+        second: Box::new((0, 0)),
+        ignored: Vec::with_capacity(1024),
+    };
+
+    let got = normal.heap_size_of_children();
+    assert_eq!(got, 9 + 2 * 4);
 }

--- a/derive/test.rs
+++ b/derive/test.rs
@@ -3,6 +3,7 @@ extern crate heapsize_derive;
 extern crate heapsize;
 
 use heapsize::HeapSizeOf;
+use std::mem;
 
 #[derive(HeapSizeOf)]
 struct Tuple([Box<u32>; 2], Box<u8>);
@@ -13,6 +14,12 @@ fn tuple_struct() {
         Tuple([Box::new(1), Box::new(2)], Box::new(3)).heap_size_of_children(),
         9
     );
+}
+
+#[test]
+fn sanity_check_heapsize_works_as_expected() {
+    assert_eq!(Box::new(1_u8).heap_size_of_children(), mem::size_of::<u8>());
+    assert_eq!([Box::new(1), Box::new(2)].heap_size_of_children(), 2 * 4);
 }
 
 #[derive(HeapSizeOf)]


### PR DESCRIPTION
I just encountered an issue where the `heapSizeOf` derive wasn't able to parse `dyn Trait` in a struct, so I thought I'd make a PR to update `heapsize_derive` to use the latest versions of `syn` and `quote`... Unfortunately almost all of `syn`'s API has changed since the custom derive was originally written, so the simple `cargo update` turned into a rewrite :disappointed: 

We'll probably want to test this PR against a large-ish codebase that already uses `heapsize` to make sure I didn't accidentally introduce any regressions.